### PR TITLE
Set Replicate API token and predictId as environment variables

### DIFF
--- a/.env-dev
+++ b/.env-dev
@@ -1,0 +1,7 @@
+# Replicate API token
+
+TOKEN=
+
+# (Optional: For testing) Prediction ID for testing GET requests to Replicate API
+
+TEST_PREDICT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+*.test
+*.out
+*.html
+.env

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This is a simple Go package for interacting with the Replicate (https://replicat
 
 This package is based on the HTTP APIs -- https://replicate.com/docs/reference/http. Please read the APIs to understand how it works first.
 
+## Setup
+
+Create an ".env" file.
+
+````sh
+cp .env-dev .env
+````
+
+Paste your Replicate API token into the ".env" file.
+
 ## How to use
 
 First, create a model. Go to https://replicate.com/explore to find the model you want to use. Then set up the input parameters for the model.
@@ -39,3 +49,8 @@ if err != nil {
 }    
 ````
 
+## Testing
+
+````sh
+go test -v -coverprofile coverage.out && go tool cover -html coverage.out -o coverage.html
+````

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sausheong/goreplicate
 
 go 1.18
+
+require github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/replicate.go
+++ b/replicate.go
@@ -10,7 +10,7 @@ import (
 
 var url = "https://api.replicate.com/v1/predictions"
 
-// Create a new client
+// NewClient creates a new Client
 // Client is the main struct used to interact with the Replicate HTTP APIs
 func NewClient(auth string, model *Model) *Client {
 	return &Client{

--- a/replicate_test.go
+++ b/replicate_test.go
@@ -4,14 +4,28 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/joho/godotenv"
 )
 
-var auth = "Token <token>"
+var auth = "Token " + getEnvironmentVariable("TOKEN")
 var version = "a9758cbfbd5f3c2094457d996681af52552901775aa2d6dd0b17fd15df959bef"
 var prompt1 = "An astronaut riding a horse in photorealistic style"
 var prompt2 = "modern kids play area landscape architecture, water play area, floating kids, seating areas, perspective view, rainy weather, biopunk, cinematic photo, highly detailed, cinematic lighting, ultra-detailed, ultrarealistic, photorealism"
 var prompt3 = "victorian rocking toy carousel theme park horse, overgrown, zdzisław beksiński, hr giger, mystical occult symbol in real life, high detail, green fog"
 var prompt4 = "woman, beautiful, elegany, golden braided hair golden eyes, green and gold caftan, dress, smiling, fairy, shiny, realistic ,4k"
+
+func getEnvironmentVariable(key string) string {
+	if env, err := godotenv.Read(); err == nil {
+		if value, ok := env[key]; ok {
+			return value
+		}
+		fmt.Println(key + " not found in .env file")
+		return ""
+	}
+	fmt.Println("Error loading .env file")
+	return ""
+}
 
 // TODO: improve on test cases
 func TestClientCreateRequest(t *testing.T) {
@@ -29,7 +43,7 @@ func TestClientCreateRequest(t *testing.T) {
 }
 
 func TestGetRequest(t *testing.T) {
-	predictId := "q3iywr5thzdsvkpscbhb6mddyu"
+	predictId := getEnvironmentVariable("TEST_PREDICT_ID")
 	fmt.Println("get request:", predictId)
 	model := NewModel("stability-ai", "stable-diffusion", version)
 	cl2 := NewClient(auth, model)


### PR DESCRIPTION
## Proposed changes

- Set Replicate API token and predictId (for testing) as environment variables in ".env" file instead of hard-coding them.
- Add setup instructions (".env" file) and test coverage instructions to README.