### PR TITLE
Clarify token format in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Then create a client, passing into it the API authentication token (you can get 
 Using the client you can send a create prediction call to the API to start the prediction.
 
 ````go
+auth := "Token <your API token>"
 client := NewClient(auth, model)
 err := client.Create()
 if err != nil {

--- a/replicate_test.go
+++ b/replicate_test.go
@@ -18,13 +18,19 @@ func TestClientCreateRequest(t *testing.T) {
 	model := NewModel("stability-ai", "stable-diffusion", version)
 	fmt.Printf("%#v", model)
 	model.Input["prompt"] = prompt3
-	model.Input["num_outputs"] = 4
+	model.Input["num_outputs"] = 1
 
 	client := NewClient(auth, model)
 	err := client.Create()
 	if err != nil {
 		t.Error(err)
 	}
+
+	// Only expect "starting" to be passing
+	if client.Response.Status != "starting" {
+		t.Errorf("expected status to be starting, got %s", client.Response.Status)
+	}
+
 	t.Logf("%#v", client.Response)
 }
 

--- a/structs.go
+++ b/structs.go
@@ -26,13 +26,13 @@ type Response struct {
 		Get    string `json:"get"`
 		Cancel string `json:"cancel"`
 	} `json:"urls"`
-	CreatedAt   time.Time `json:"created_at"`
-	CompletedAt time.Time `json:"completed_at"`
-	Status      string    `json:"status"`
-	Input       any       `json:"input"`
-	Output      any       `json:"output"`
-	Error       string    `json:"error"`
-	Logs        string    `json:"logs"`
+	CreatedAt   time.Time   `json:"created_at"`
+	CompletedAt time.Time   `json:"completed_at"`
+	Status      interface{} `json:"status"`
+	Input       any         `json:"input"`
+	Output      any         `json:"output"`
+	Error       string      `json:"error"`
+	Logs        string      `json:"logs"`
 	Metrics     struct {
 		PredictTime float64 `json:"predict_time"`
 	} `json:"metrics"`

--- a/structs.go
+++ b/structs.go
@@ -36,6 +36,12 @@ type Response struct {
 	Metrics     struct {
 		PredictTime float64 `json:"predict_time"`
 	} `json:"metrics"`
+	Title         string `json:"title"`
+	InvalidFields []struct {
+		Type        string `json:"type"`
+		Field       string `json:"field"`
+		Description string `json:"description"`
+	} `json:"invalid_fields"`
 }
 
 // Model is the model that represents the model to be used for prediction


### PR DESCRIPTION
Verify prediction as "starting" in test
Response.status can be an int (422) if request is malformed. But debugging was difficult because body was not being unmarshalled because it did not expect an int in status and was failing